### PR TITLE
Remove the redefinition of   `struct gsm_dlci_config`

### DIFF
--- a/ExploitGSM_6_5/main.c
+++ b/ExploitGSM_6_5/main.c
@@ -50,16 +50,6 @@
 #define HEAP_SPRAY_SIZE 1024
 #define BITS_PER_LONG 64
 
-struct gsm_dlci_config {
-    __u32 channel;		/* DLCI (0 for the associated DLCI) */
-    __u32 adaption;		/* Convergence layer type */
-    __u32 mtu;		/* Maximum transfer unit */
-    __u32 priority;		/* Priority (0 for default value) */
-    __u32 i;		/* Frame type (1 = UIH, 2 = UI) */
-    __u32 k;		/* Window size (0 for default value) */
-    __u32 reserved[8];	/* For future use, must be initialized to zero */
-};
-
 #define GSMIOC_GETCONF_DLCI	_IOWR('G', 7, struct gsm_dlci_config)
 #define GSMIOC_SETCONF_DLCI	_IOW('G', 8, struct gsm_dlci_config)
 


### PR DESCRIPTION
Remove the redefinition of ```struct gsm_dlci_config``` from the main.c file. Since the structure is already defined in the ```/usr/include/linux/gsmmux.h``` header file 

which leads to this error

```c
[ 50%] Building C object CMakeFiles/ExploitGSM.dir/main.c.o /home/xxx/ExploitGSM/ExploitGSM_6_5/main.c:53:8: error: redefinition of ‘struct gsm_dlci_config’ 53 | struct gsm_dlci_config { | ^~~~~~~~~~~~~~~ In file included from /home/xxx/ExploitGSM/ExploitGSM_6_5/main.c:7: /usr/include/linux/gsmmux.h:54:8: note: originally defined here 54 | struct gsm_dlci_config { | ^~~~~~~~~~~~~~~ gmake[2]: *** [CMakeFiles/ExploitGSM.dir/build.make:76: CMakeFiles/ExploitGSM.dir/main.c.o] Error 1 gmake[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/ExploitGSM.dir/all] Error 2 gmake: *** [Makefile:91: all] Error 2
```