### PR TITLE
Update ExploitGSM_6_5/main.c

### DIFF
--- a/ExploitGSM_6_5/main.c
+++ b/ExploitGSM_6_5/main.c
@@ -50,6 +50,7 @@
 #define HEAP_SPRAY_SIZE 1024
 #define BITS_PER_LONG 64
 
+#ifndef GSMIOC_SETCONF_EXT
 struct gsm_dlci_config {
     __u32 channel;		/* DLCI (0 for the associated DLCI) */
     __u32 adaption;		/* Convergence layer type */
@@ -62,6 +63,7 @@ struct gsm_dlci_config {
 
 #define GSMIOC_GETCONF_DLCI	_IOWR('G', 7, struct gsm_dlci_config)
 #define GSMIOC_SETCONF_DLCI	_IOW('G', 8, struct gsm_dlci_config)
+#endif
 
 const unsigned char CMD_CLD =   0x61;
 const unsigned char CMD_TEST =  0x11;

--- a/ExploitGSM_6_5/main.c
+++ b/ExploitGSM_6_5/main.c
@@ -519,7 +519,7 @@ int main(int argc, char *argv[]) {
 
     if (argc < 1 || argv[1] == 0)
     {
-        fprintf(stderr, "Input distro name to arg, example ./Exploit ubuntu|fedora");
+        fprintf(stderr, "Input distro name to arg, example ./Exploit ubuntu|fedora\n");
         goto error_arg;
     }
 
@@ -1020,14 +1020,15 @@ int main(int argc, char *argv[]) {
     retval = pthread_create(&tid_spray, &tattr_alloc_dlci, thread_spray_kheap, &arg_spray);
     if (retval != 0)
     {
-        fprintf(stderr, "Error create setconf dlci thread, %s \n", strerror(retval));
+        fprintf(stderr, "Error create spray thread, %s \n", strerror(retval));
         goto error_create_spray;
     }
 
+    printf("waiting spray thread \n");
     retval = pthread_join(tid_spray, NULL);
     if (retval != 0)
     {
-        fprintf(stderr, "Error thread join to spray thread %s \n", strerror(retval));
+        fprintf(stderr, "Error join to spray thread %s \n", strerror(retval));
         goto error_spray;
     }
 


### PR DESCRIPTION
The struct `gsm_dlci_config` defined in the header file `linux/gsmmux.h` was added on [**Mar 29, 2023**](https://github.com/torvalds/linux/commit/4ca589661d964840d0d5de4b3baabbef78f453e3#diff-6d37aa211c344568165e2c0a9c83b4037f5205a3552e5cf1d2553e6733325820R53-R66).

Since there have been related pull requests trying to delete and revert, I thought it might be a problem with the differences between distributions, so instead I used `#ifndef` to confirm the definition to avoid errors.

In addition, some kernels may get stuck in the join `spray` or `setconf dlci` thread during execution (but I don't know why), so adding hints will make it easier to determine whether or not to re-execute.